### PR TITLE
Color branches

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -405,7 +405,7 @@
                     type="color"
                     id="defaultBranchColor"
                     class="skip"
-                    value="#ccc"
+                    value="#cccccc"
                  >
                 </div>
                 <div class="form-group">
@@ -804,7 +804,6 @@
       });
 
       d3.select("#highlightLeaves").on("input", function() {
-        // console.log("tree", tree.getNodeGUIDs(this.value));
         if (d3.select("#highlightLeaves").property("checked")) {
           tree.setColorOptions({
             nodeColorMode: "list",
@@ -815,6 +814,9 @@
             nodeList: tree.getNodeGUIDs(true)
           })
         } else {
+          if (d3.select("#highlightBranches").property("checked")) {
+            d3.select("#highlightBranches").property("checked", false);
+          }
           tree.setColorOptions({
             nodeColorMode: "none",
             branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
@@ -831,7 +833,7 @@
           if (!d3.select("#highlightLeaves").property("checked")) {
             d3.select("#highlightLeaves").property("checked", true);
           }
-          setColorOptions({
+          tree.setColorOptions({
             nodeColorMode: "list",
             branchColorMode: "monophyletic",
             defaultNodeColor: d3.select("#defaultNodeColor").node().value,
@@ -840,7 +842,7 @@
             nodeList: tree.getNodeGUIDs(true)
           })
         } else {
-          setColorOptions({
+          tree.setColorOptions({
             nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
             branchColorMode: "none",
             defaultNodeColor: d3.select("#defaultNodeColor").node().value,

--- a/app/index.html
+++ b/app/index.html
@@ -769,7 +769,7 @@
 */
       d3.select("#defaultNodeColor").on("input", function() {
         tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
           branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
           defaultNodeColor: this.value,
           defaultBranchColor: d3.select("#defaultBranchColor").node().value,
@@ -780,7 +780,7 @@
 
       d3.select("#defaultBranchColor").on("input", function() {
         tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
           branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
           defaultNodeColor: d3.select("#defaultNodeColor").node().value,
           defaultBranchColor: this.value,
@@ -794,7 +794,7 @@
             d3.select("#highlightLeaves").property("checked",true);
         }
         tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
           branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
           defaultNodeColor: d3.select("#defaultNodeColor").node().value,
           defaultBranchColor: d3.select("#defaultBranchColor").node().value,

--- a/app/index.html
+++ b/app/index.html
@@ -740,6 +740,24 @@
           tree.setAnimation(cached);
         });
 
+      // Checks if the given node, or all of its leaves, is an E. Coli or Shigella node.
+      //
+      // Parameters:
+      // - node: The node to check.
+      //
+      // Returns:
+      // - true if the node, or all of its leaves, is an E. Coli or Shigella node, false otherwise.
+      isEColiOrShigellaNode = function(node) {
+        // this bc its recursive and the children are organized differently
+        let nodeData = node.__data__ ? node.__data__.data : node;
+       
+        if (nodeData.children.length === 0) {
+          return nodeData.id.includes("Escherichia_coli") || nodeData.id.includes("Shigella");
+        } else {
+          return nodeData.children.every(isEColiOrShigellaNode);
+        }
+      }
+
       d3.select("#highlightMode").on("input", function() {
         if (this.value === "none") {
           tree.setColorOptions({
@@ -765,9 +783,7 @@
             defaultNodeColor: d3.select("#defaultNodeColor").node().value,
             defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
-            // todo set to false, to get branch nodes too
-            // todo update this fxn, or add another, to return GUIDs based on some attribute, or the id of the node
-            nodeList: tree.getNodeGUIDs(true)
+            nodeList: tree.getNodeGUIDs(false, isEColiOrShigellaNode)
           })
         }
       });
@@ -779,8 +795,7 @@
           defaultNodeColor: this.value,
           defaultBranchColor: d3.select("#defaultBranchColor").node().value,
           highlightColor: d3.select("#highlightColor").node().value,
-          // todo make this dependent on highlightMode, once this fxn is updated
-          nodeList: tree.getNodeGUIDs(true)
+          nodeList: d3.select("#highlightMode").property("value") === "monophyletic" ? tree.getNodeGUIDs(false, isEColiOrShigellaNode) : tree.getNodeGUIDs(true)
         });
       });
 
@@ -791,8 +806,7 @@
           defaultNodeColor: d3.select("#defaultNodeColor").node().value,
           defaultBranchColor: this.value,
           highlightColor: d3.select("#highlightColor").node().value,
-          // todo make this dependent on highlightMode, once this fxn is updated
-          nodeList: tree.getNodeGUIDs(true)
+          nodeList: d3.select("#highlightMode").property("value") === "monophyletic" ? tree.getNodeGUIDs(false, isEColiOrShigellaNode) : tree.getNodeGUIDs(true)
         });
       });
 
@@ -803,8 +817,7 @@
           defaultNodeColor: d3.select("#defaultNodeColor").node().value,
           defaultBranchColor: d3.select("#defaultBranchColor").node().value,
           highlightColor: this.value,
-          // todo make this dependent on highlightMode, once this fxn is updated
-          nodeList: tree.getNodeGUIDs(true)
+          nodeList: d3.select("#highlightMode").property("value") === "monophyletic" ? tree.getNodeGUIDs(false, isEColiOrShigellaNode) : tree.getNodeGUIDs(true)
         });
       });
       

--- a/app/index.html
+++ b/app/index.html
@@ -386,10 +386,14 @@
               data-parent="#accordion"
             >
               <div class="card-body">
-              <!--    <div class="form-group">
-                    <label for="colorMode">Color Mode</label>
-                    <select id="colorMode" class="form-control form-control-sm skip"></select>
-                   </div> -->
+                <div class="form-group">
+                  <label for="highlightMode">Highlighting Example</label>
+                  <select id="highlightMode" class="form-control form-control-sm skip">
+                    <option value="none">No highlighting</option>
+                    <option value="leaves">Highlight leaf nodes</option>
+                    <option value="monophyletic">Highlight E. coli and Shigella branches+nodes</option>
+                  </select>
+                </div>
                 <div class="form-group">
                   <label>Default Node Color</label>
                   <input
@@ -416,20 +420,6 @@
                     class="skip"
                     value="#feb640"
                  >
-                </div>
-                <div class="form-group">
-                  <div class="switch">
-                    <label>
-                      <input id="highlightLeaves" type="checkbox" class="skip"> Highlight Leaves
-                    </label>
-                  </div>
-                </div>
-                <div class="form-group">
-                  <div class="switch">
-                    <label>
-                      <input id="highlightBranches" type="checkbox" class="skip"> Highlight Branches
-                    </label>
-                  </div>
                 </div>
               </div>
             </div>
@@ -750,107 +740,72 @@
           tree.setAnimation(cached);
         });
 
-        // might want this back when we have more color mode options
-        // for now, ill leave it out in favor of the highlight toggle
-/*      d3.select("#colorMode").on("input", function() {
-        // this could prove annoying, but ill leave it for now
-        if (this.value === "list") {
-          d3.select("#defaultNodeColor").node().value = "#243127";
-        } else {
-          d3.select("#defaultNodeColor").node().value = "#4682B4";
-        }
-
-        tree.setColorOptions({ 
-          colorMode: this.value,
-          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
-          highlightColor: d3.select("#highlightColor").node().value
-        });
-      });
-*/
-      d3.select("#defaultNodeColor").on("input", function() {
-        tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
-          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-          defaultNodeColor: this.value,
-          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
-          highlightColor: d3.select("#highlightColor").node().value,
-          nodeList: tree.getNodeGUIDs(true)
-        });
-      });
-
-      d3.select("#defaultBranchColor").on("input", function() {
-        tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
-          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
-          defaultBranchColor: this.value,
-          highlightColor: d3.select("#highlightColor").node().value,
-          nodeList: tree.getNodeGUIDs(true)
-        });
-      });
-
-      d3.select("#highlightColor").on("input", function() {
-        if (!d3.select("#highlightLeaves").property("checked")) {
-            d3.select("#highlightLeaves").property("checked",true);
-        }
-        tree.setColorOptions({ 
-          nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
-          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
-          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
-          highlightColor: this.value,
-          nodeList: tree.getNodeGUIDs(true)
-        });
-      });
-
-      d3.select("#highlightLeaves").on("input", function() {
-        if (d3.select("#highlightLeaves").property("checked")) {
+      d3.select("#highlightMode").on("input", function() {
+        if (this.value === "none") {
+          tree.setColorOptions({
+            nodeColorMode: "none",
+            branchColorMode: "none",
+            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
+            highlightColor: d3.select("#highlightColor").node().value
+          });
+        } else if (this.value === "leaves") {
           tree.setColorOptions({
             nodeColorMode: "list",
-            branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
+            branchColorMode: "none",
             defaultNodeColor: d3.select("#defaultNodeColor").node().value,
             defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(true)
-          })
-        } else {
-          if (d3.select("#highlightBranches").property("checked")) {
-            d3.select("#highlightBranches").property("checked", false);
-          }
-          tree.setColorOptions({
-            nodeColorMode: "none",
-            branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
-            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
-            highlightColor: d3.select("#highlightColor").node().value,
-            nodeList: tree.getNodeGUIDs(false)
-          })
-        }
-      });
-
-      d3.select("#highlightBranches").on("input", function() {
-        if (d3.select("#highlightBranches").property("checked")) {
-          if (!d3.select("#highlightLeaves").property("checked")) {
-            d3.select("#highlightLeaves").property("checked", true);
-          }
+          });
+        } else if (this.value === "monophyletic") {
           tree.setColorOptions({
             nodeColorMode: "list",
             branchColorMode: "monophyletic",
             defaultNodeColor: d3.select("#defaultNodeColor").node().value,
             defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
-            nodeList: tree.getNodeGUIDs(true)
-          })
-        } else {
-          tree.setColorOptions({
-            nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
-            branchColorMode: "none",
-            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
-            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
-            highlightColor: d3.select("#highlightColor").node().value,
+            // todo set to false, to get branch nodes too
+            // todo update this fxn, or add another, to return GUIDs based on some attribute, or the id of the node
             nodeList: tree.getNodeGUIDs(true)
           })
         }
+      });
+
+      d3.select("#defaultNodeColor").on("input", function() {
+        tree.setColorOptions({ 
+          nodeColorMode: d3.select("#highlightMode").property("value") === "none" ? "none" : "list",
+          branchColorMode: d3.select("#highlightMode").property("value") === "monophyletic" ? "monophyletic" : "none",
+          defaultNodeColor: this.value,
+          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
+          highlightColor: d3.select("#highlightColor").node().value,
+          // todo make this dependent on highlightMode, once this fxn is updated
+          nodeList: tree.getNodeGUIDs(true)
+        });
+      });
+
+      d3.select("#defaultBranchColor").on("input", function() {
+        tree.setColorOptions({ 
+          nodeColorMode: d3.select("#highlightMode").property("value") === "none" ? "none" : "list",
+          branchColorMode: d3.select("#highlightMode").property("value") === "monophyletic" ? "monophyletic" : "none",
+          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+          defaultBranchColor: this.value,
+          highlightColor: d3.select("#highlightColor").node().value,
+          // todo make this dependent on highlightMode, once this fxn is updated
+          nodeList: tree.getNodeGUIDs(true)
+        });
+      });
+
+      d3.select("#highlightColor").on("input", function() {
+        tree.setColorOptions({ 
+          nodeColorMode: d3.select("#highlightMode").property("value") === "none" ? "none" : "list",
+          branchColorMode: d3.select("#highlightMode").property("value") === "monophyletic" ? "monophyletic" : "none",
+          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
+          highlightColor: this.value,
+          // todo make this dependent on highlightMode, once this fxn is updated
+          nodeList: tree.getNodeGUIDs(true)
+        });
       });
       
       d3.select("#branchNodeSize").on("input", function() {

--- a/app/index.html
+++ b/app/index.html
@@ -415,6 +415,13 @@
                     </label>
                   </div>
                 </div>
+                <div class="form-group">
+                  <div class="switch">
+                    <label>
+                      <input id="highlightBranches" type="checkbox" class="skip"> Highlight Branches
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/app/index.html
+++ b/app/index.html
@@ -664,7 +664,7 @@
         fetch("life.nwk").then(response => response.text().then(buildTree));
       });
 
-      ["layout", "mode", "type", "nodeColorMode", "branchColorMode"].forEach(thing => {
+      ["layout", "mode", "type"].forEach(thing => {
         var title = "valid" + thing[0].toUpperCase() + thing.slice(1) + "s";
         d3.select("#" + thing)
           .selectAll("option")

--- a/app/index.html
+++ b/app/index.html
@@ -664,7 +664,7 @@
         fetch("life.nwk").then(response => response.text().then(buildTree));
       });
 
-      ["layout", "mode", "type", "colorMode"].forEach(thing => {
+      ["layout", "mode", "type", "nodeColorMode", "branchColorMode"].forEach(thing => {
         var title = "valid" + thing[0].toUpperCase() + thing.slice(1) + "s";
         d3.select("#" + thing)
           .selectAll("option")
@@ -690,7 +690,8 @@
             type: d3.select("#type").node().value,
             colorOptions: 
             { 
-              colorMode: "list",
+              nodeColorMode: "list",
+              branchColorMode: "monophyletic",
               defaultColor: d3.select("#defaultColor").node().value,
               highlightColor: d3.select("#highlightColor").node().value,
             },
@@ -758,7 +759,8 @@
 */
       d3.select("#defaultColor").on("input", function() {
         tree.setColorOptions({ 
-          colorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
           defaultColor: this.value,
           highlightColor: d3.select("#highlightColor").node().value,
           nodeList: tree.getNodeGUIDs(true)
@@ -770,7 +772,8 @@
             d3.select("#highlightLeaves").property("checked",true);
         }
         tree.setColorOptions({ 
-          colorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
           defaultColor: d3.select("#defaultColor").node().value,
           highlightColor: this.value,
           nodeList: tree.getNodeGUIDs(true)
@@ -781,17 +784,42 @@
         // console.log("tree", tree.getNodeGUIDs(this.value));
         if (d3.select("#highlightLeaves").property("checked")) {
           tree.setColorOptions({
-            colorMode: "list",
+            nodeColorMode: "list",
+            branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
             defaultColor: d3.select("#defaultColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(true)
           })
         } else {
           tree.setColorOptions({
-            colorMode: "none",
+            nodeColorMode: "none",
+            branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
             defaultColor: d3.select("#defaultColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(false)
+          })
+        }
+      });
+
+      d3.select("#highlightBranches").on("input", function() {
+        if (d3.select("#highlightBranches").property("checked")) {
+          if (!d3.select("#highlightLeaves").property("checked")) {
+            d3.select("#highlightLeaves").property("checked", true);
+          }
+          setColorOptions({
+            nodeColorMode: "list",
+            branchColorMode: "monophyletic",
+            defaultColor: d3.select("#defaultColor").node().value,
+            highlightColor: d3.select("#highlightColor").node().value,
+            nodeList: tree.getNodeGUIDs(true)
+          })
+        } else {
+          setColorOptions({
+            nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
+            branchColorMode: "none",
+            defaultColor: d3.select("#defaultColor").node().value,
+            highlightColor: d3.select("#highlightColor").node().value,
+            nodeList: tree.getNodeGUIDs(true)
           })
         }
       });

--- a/app/index.html
+++ b/app/index.html
@@ -391,12 +391,21 @@
                     <select id="colorMode" class="form-control form-control-sm skip"></select>
                    </div> -->
                 <div class="form-group">
-                  <label>Default Color</label>
+                  <label>Default Node Color</label>
                   <input
                     type="color"
-                    id="defaultColor"
+                    id="defaultNodeColor"
                     class="skip"
                     value="#4682B4"
+                 >
+                </div>
+                <div class="form-group">
+                  <label>Default Branch Color</label>
+                  <input
+                    type="color"
+                    id="defaultBranchColor"
+                    class="skip"
+                    value="#ccc"
                  >
                 </div>
                 <div class="form-group">
@@ -692,7 +701,8 @@
             { 
               nodeColorMode: "list",
               branchColorMode: "monophyletic",
-              defaultColor: d3.select("#defaultColor").node().value,
+              defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+              defaultBranchColor: d3.select("#defaultBranchColor").node().value,
               highlightColor: d3.select("#highlightColor").node().value,
             },
             leafNodes: d3.select("#leafNodes").node().checked,
@@ -745,23 +755,35 @@
 /*      d3.select("#colorMode").on("input", function() {
         // this could prove annoying, but ill leave it for now
         if (this.value === "list") {
-          d3.select("#defaultColor").node().value = "#243127";
+          d3.select("#defaultNodeColor").node().value = "#243127";
         } else {
-          d3.select("#defaultColor").node().value = "#4682B4";
+          d3.select("#defaultNodeColor").node().value = "#4682B4";
         }
 
         tree.setColorOptions({ 
           colorMode: this.value,
-          defaultColor: d3.select("#defaultColor").node().value,
+          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
           highlightColor: d3.select("#highlightColor").node().value
         });
       });
 */
-      d3.select("#defaultColor").on("input", function() {
+      d3.select("#defaultNodeColor").on("input", function() {
         tree.setColorOptions({ 
           nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
           branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-          defaultColor: this.value,
+          defaultNodeColor: this.value,
+          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
+          highlightColor: d3.select("#highlightColor").node().value,
+          nodeList: tree.getNodeGUIDs(true)
+        });
+      });
+
+      d3.select("#defaultBranchColor").on("input", function() {
+        tree.setColorOptions({ 
+          nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
+          branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
+          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+          defaultBranchColor: this.value,
           highlightColor: d3.select("#highlightColor").node().value,
           nodeList: tree.getNodeGUIDs(true)
         });
@@ -774,7 +796,8 @@
         tree.setColorOptions({ 
           nodeColorMode: d3.select("#highlightLeaves").node().value ? "list" : "none",
           branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-          defaultColor: d3.select("#defaultColor").node().value,
+          defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+          defaultBranchColor: d3.select("#defaultBranchColor").node().value,
           highlightColor: this.value,
           nodeList: tree.getNodeGUIDs(true)
         });
@@ -786,7 +809,8 @@
           tree.setColorOptions({
             nodeColorMode: "list",
             branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-            defaultColor: d3.select("#defaultColor").node().value,
+            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(true)
           })
@@ -794,7 +818,8 @@
           tree.setColorOptions({
             nodeColorMode: "none",
             branchColorMode: d3.select("#highlightBranches").property("checked") ? "monophyletic" : "none",
-            defaultColor: d3.select("#defaultColor").node().value,
+            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(false)
           })
@@ -809,7 +834,8 @@
           setColorOptions({
             nodeColorMode: "list",
             branchColorMode: "monophyletic",
-            defaultColor: d3.select("#defaultColor").node().value,
+            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(true)
           })
@@ -817,7 +843,8 @@
           setColorOptions({
             nodeColorMode: d3.select("#highlightLeaves").property("checked") ? "list" : "none",
             branchColorMode: "none",
-            defaultColor: d3.select("#defaultColor").node().value,
+            defaultNodeColor: d3.select("#defaultNodeColor").node().value,
+            defaultBranchColor: d3.select("#defaultBranchColor").node().value,
             highlightColor: d3.select("#highlightColor").node().value,
             nodeList: tree.getNodeGUIDs(true)
           })

--- a/src/main.js
+++ b/src/main.js
@@ -405,7 +405,7 @@ function findNodeColor(node, colorOptions) {
  */
 function findLinkColor(link, colorOptions) {
   if (colorOptions.linkColorMode === "none") {
-    return colorOptions.defaultColor ?? "#243127";
+    return colorOptions.defaultColor ?? "#ccc";
   }
 
   let source = link.source;
@@ -419,7 +419,7 @@ function findLinkColor(link, colorOptions) {
     return colorOptions.highlightColor ?? "#feb640";
   }
 
-  return colorOptions.defaultColor ?? "#243127";
+  return colorOptions.defaultColor ?? "#ccc";
 }
 
 function getAllLeaves(node) {

--- a/src/main.js
+++ b/src/main.js
@@ -574,7 +574,7 @@ TidyTree.prototype.redraw = function () {
       newLinks
         .append("path")
         .attr("fill", "none")
-        .attr("stroke", "#ccc")
+        .attr("stroke", d => findLinkColor(d, this.colorOptions))
         .attr("d", linkTransformer)
         .transition()
         .duration(this.animation)
@@ -601,6 +601,7 @@ TidyTree.prototype.redraw = function () {
         paths
           .transition()
           .duration(this.animation / 2)
+          .attr("stroke", d => findLinkColor(d, this.colorOptions))
           .attr("opacity", 0)
           .end()
           .then(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -382,7 +382,7 @@ nodeTransformers.dendrogram = nodeTransformers.tree;
 function findNodeColor(node, colorOptions) {
   if (colorOptions.nodeColorMode === "none") {
     // steelblue
-    return colorOptions.defaultColor ?? "#4682B4";
+    return colorOptions.defaultNodeColor ?? "#4682B4";
   }
  
   let nodeList = colorOptions.nodeList;
@@ -392,7 +392,7 @@ function findNodeColor(node, colorOptions) {
     return colorOptions.highlightColor ?? "#feb640";
   } else {
     // charcoal
-    return colorOptions.defaultColor ?? "#243127";
+    return colorOptions.defaultNodeColor ?? "#243127";
   }
 }
 
@@ -405,12 +405,12 @@ function findNodeColor(node, colorOptions) {
  */
 function findBranchColor(link, colorOptions) {
   if (colorOptions.branchColorMode === "none") {
-    return colorOptions.defaultColor ?? "#ccc";
+    return colorOptions.defaultBranchColor ?? "#ccc";
   }
   
   let source = link.source;
   let childLeaves = getAllLeaves(source);
-  console.log("childLeaves", childLeaves);
+  
   let allChildLeavesInNodeList = childLeaves.every(childLeaf =>
     colorOptions.nodeList?.includes(childLeaf.data._guid)
   );
@@ -419,7 +419,7 @@ function findBranchColor(link, colorOptions) {
     return colorOptions.highlightColor ?? "#feb640";
   }
 
-  return colorOptions.defaultColor ?? "#ccc";
+  return colorOptions.defaultBranchColor ?? "#ccc";
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -405,27 +405,35 @@ function findNodeColor(node, colorOptions) {
  */
 function findLinkColor(link, colorOptions) {
   if (colorOptions.linkColorMode === "none") {
-    // charcoal
     return colorOptions.defaultColor ?? "#243127";
   }
+
   let source = link.source;
+  let children = getAllLeaves(source);
 
-  // todo modify this to find all leaves rather than all children
-  // find all children of the source
-  let children = source.children;
+  let allChildrenInNodeList = children.every(child =>
+    colorOptions.nodeList.includes(child.data._guid)
+  );
 
-  // check if all children are in the node list
-  let allChildrenInNodeList = children.every(child => colorOptions.nodeList.includes(child.data._guid));
-
-  // if all of the children are in the node list, return the highlight color
   if (allChildrenInNodeList) {
-    // yellowish
     return colorOptions.highlightColor ?? "#feb640";
   }
 
-  // otherwise, return the default color
   return colorOptions.defaultColor ?? "#243127";
+}
+
+function getAllLeaves(node) {
+  let leaves = [];
+
+  if (node.children.length === 0) {
+    leaves.push(node);
+  } else {
+    node.children.forEach(child => {
+      leaves.push(...getAllLeaves(child));
+    });
   }
+
+  return leaves;
 }
 
 const radToDeg = 180 / Math.PI;

--- a/src/main.js
+++ b/src/main.js
@@ -405,21 +405,27 @@ function findNodeColor(node, colorOptions) {
  */
 function findBranchColor(link, colorOptions) {
   if (colorOptions.branchColorMode === "none") {
-    return colorOptions.defaultBranchColor ?? "#ccc";
+    // light gray
+    return colorOptions.defaultBranchColor ?? "#cccccc";
   }
   
   let source = link.source;
-  let children = source.children;
+  //let children = source.children;
+  let childLeafNodes = getAllLeaves(source);
   
-  let allChildrenInNodeList = children.every(child =>
+  //let allChildrenInNodeList = children.every(child =>
+  //  colorOptions.nodeList?.includes(child.data._guid)
+  //);
+  let allChildLeafNodesInNodeList = childLeafNodes.every(child =>
     colorOptions.nodeList?.includes(child.data._guid)
   );
  
-  if (allChildrenInNodeList) {
+  if (allChildLeafNodesInNodeList) {
+    // yellowish
     return colorOptions.highlightColor ?? "#feb640";
   }
 
-  return colorOptions.defaultBranchColor ?? "#ccc";
+  return colorOptions.defaultBranchColor ?? "#cccccc";
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -410,12 +410,8 @@ function findBranchColor(link, colorOptions) {
   }
   
   let source = link.source;
-  //let children = source.children;
   let childLeafNodes = getAllLeaves(source);
   
-  //let allChildrenInNodeList = children.every(child =>
-  //  colorOptions.nodeList?.includes(child.data._guid)
-  //);
   let allChildLeafNodesInNodeList = childLeafNodes.every(child =>
     colorOptions.nodeList?.includes(child.data._guid)
   );
@@ -1229,10 +1225,10 @@ TidyTree.prototype.setRuler = function (show) {
  * Retrieves the GUIDs of the nodes in the TidyTree instance.
  *
  * @param {boolean} leavesOnly - Whether to retrieve GUIDs only for leaf nodes.
+ * @param {function} predicate - A function that returns true if the node should be included
  * @return {Array} An array of GUIDs of the nodes.
  */
-TidyTree.prototype.getNodeGUIDs = function (leavesOnly) {
-  // todo: make sure these are returned in order
+TidyTree.prototype.getNodeGUIDs = function (leavesOnly, predicate) {
   let nodeList = this.parent
     .select("svg")
     .selectAll("g.tidytree-node-leaf circle")
@@ -1247,7 +1243,9 @@ TidyTree.prototype.getNodeGUIDs = function (leavesOnly) {
 
   let nodeGUIDs = [];
   for (const node of nodeList.values()) {
-    nodeGUIDs.push(node.__data__.data._guid);
+    if (!predicate || predicate(node)) {
+      nodeGUIDs.push(node.__data__.data._guid);
+    }
   }
 
   return nodeGUIDs;

--- a/src/main.js
+++ b/src/main.js
@@ -409,13 +409,13 @@ function findBranchColor(link, colorOptions) {
   }
   
   let source = link.source;
-  let childLeaves = getAllLeaves(source);
+  let children = source.children;
   
-  let allChildLeavesInNodeList = childLeaves.every(childLeaf =>
-    colorOptions.nodeList?.includes(childLeaf.data._guid)
+  let allChildrenInNodeList = children.every(child =>
+    colorOptions.nodeList?.includes(child.data._guid)
   );
-
-  if (allChildLeavesInNodeList) {
+ 
+  if (allChildrenInNodeList) {
     return colorOptions.highlightColor ?? "#feb640";
   }
 
@@ -604,7 +604,9 @@ TidyTree.prototype.redraw = function () {
       let linkTransformer = linkTransformers[this.type][this.mode][this.layout];
       let paths = update.select("path");
       if (!this.animation > 0) {
-        paths.attr("d", linkTransformer);
+        paths
+        .attr("d", linkTransformer)
+        .attr("stroke", d => findBranchColor(d, this.colorOptions));
       } else {
         paths
           .transition()


### PR DESCRIPTION
this one adds:
1. the ability to change the default color of branches
2. ability to highlight/ color branches which are related to your highlighted/ colored nodes (starting w monophyletic relationships)
3. the ability to find node guids by predicate

and modifies:
1. the color menu, by replacing the highlight nodes toggle w a few dedicated highlighting examples